### PR TITLE
Allow choosing custom vaidation messages. Fixes #46

### DIFF
--- a/app/assets/javascripts/viewmodels/poll.js.coffee
+++ b/app/assets/javascripts/viewmodels/poll.js.coffee
@@ -17,6 +17,15 @@ class @Question
     @max_length = ko.observable(data.max_length)
     @must_contain = ko.observable(data.must_contain)
 
+    # Custom messages
+    custom_messages = data.custom_messages || {}
+    @custom_message_empty = ko.observable(custom_messages.empty)
+    @custom_message_invalid_length = ko.observable(custom_messages.invalid_length)
+    @custom_message_doesnt_contain = ko.observable(custom_messages.doesnt_contain)
+    @custom_message_not_a_number = ko.observable(custom_messages.not_a_number)
+    @custom_message_number_not_in_range = ko.observable(custom_messages.number_not_in_range)
+    @custom_message_not_an_option = ko.observable(custom_messages.not_an_option)
+
     # Options list
     @options = ko.observableArray(_.map(data.options, (opt) => new QuestionOption(@, opt)))
 

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -1,17 +1,17 @@
 # Copyright (C) 2011-2012, InSTEDD
-# 
+#
 # This file is part of Pollit.
-# 
+#
 # Pollit is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # Pollit is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with Pollit.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -48,7 +48,7 @@ class Channel < ActiveRecord::Base
   def register_nuntium_channel
     @nuntium = Nuntium.new_from_config
     begin
-      channel_info = @nuntium.create_channel({ 
+      channel_info = @nuntium.create_channel({
         :name => name,
         :protocol => 'sms',
         :kind => 'qst_server',
@@ -59,7 +59,7 @@ class Channel < ActiveRecord::Base
         :configuration => { :password => SecureRandom.base64(6) },
         :enabled => true
       })
-    
+
       self.address = "sms://#{channel_info[:address]}"
     rescue Nuntium::Exception => e
       e.properties.each do |error|

--- a/app/views/polls/form_editor/_question_form.haml
+++ b/app/views/polls/form_editor/_question_form.haml
@@ -30,7 +30,7 @@
     = f.text_field :max_length, :class => "w13", :'data-bind' => 'attr: {readonly: readonly}', :type => 'number'
     %hr
     %p.title Contains
-    %p.smalltext Require this string to be contained in the response
+    %p.smalltext Require this text to be contained in the response
     = f.text_field :must_contain, :'data-bind' => 'attr: {readonly: readonly}'
     %hr
     -# HACK: Rails generates two check_boxes when using f.check_box, to ensure the falsy value is always submitted
@@ -63,5 +63,25 @@
       %input.newoption.small.option{ko(textInput: 'text', hasFocus: 'focus', event: { keypress: 'onEnter' }), type: 'text', placeholder: 'Enter a new option'}
       %buttom.right.addoption.clist-add{ko(click: 'add', visible: '(text().length > 0)')}
     .clear
+
+  %hr
+  %p.title Validation messages
+  %p.smalltext Messages to use when respondents reply with invalid answers.
+  %br/
+  - ko_if 'kind_text()' do
+    %p.smalltext The response is empty
+    = f.text_field :custom_message_empty, placeholder: "(default message)"
+    %p.smalltext The response doesn't have the required size
+    = f.text_field :custom_message_invalid_length, placeholder: "(default message)"
+    %p.smalltext The response doesn't contain the required text
+    = f.text_field :custom_message_doesnt_contain, placeholder: "(default message)"
+  - ko_if 'kind_numeric()' do
+    %p.smalltext The response is not a number
+    = f.text_field :custom_message_not_a_number, placeholder: "(default message)"
+    %p.smalltext The response number is outside the valid range
+    = f.text_field :custom_message_number_not_in_range, placeholder: "(default message)"
+  - ko_if 'kind_options()' do
+    %p.smalltext The response is not an option
+    = f.text_field :custom_message_not_an_option, placeholder: "(default message)"
 
 

--- a/db/migrate/20160211211652_add_custom_messages_to_question.rb
+++ b/db/migrate/20160211211652_add_custom_messages_to_question.rb
@@ -1,0 +1,5 @@
+class AddCustomMessagesToQuestion < ActiveRecord::Migration
+  def change
+    add_column :questions, :custom_messages, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20151113144807) do
+ActiveRecord::Schema.define(:version => 20160211211652) do
 
   create_table "answers", :force => true do |t|
     t.integer  "respondent_id"
@@ -130,6 +130,7 @@ ActiveRecord::Schema.define(:version => 20151113144807) do
     t.integer  "max_length"
     t.string   "must_contain"
     t.text     "next_question_definition"
+    t.text     "custom_messages"
   end
 
   create_table "respondents", :force => true do |t|


### PR DESCRIPTION
- Added `Question#custom_messages` that's a serialized hash
- Added UI to store messages in that hash
- Use the hash values, if defined, for the validation messages. Otherwise use the default messages

The UI looks like this (the messages depend on the current question type):

![screenshot 2016-02-12 14 12 45](https://cloud.githubusercontent.com/assets/209371/13014469/bb94ab68-d192-11e5-99e2-bb1186b28c7b.png)
