### PR TITLE
Fixed #49: duplicate polls

### DIFF
--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -153,6 +153,10 @@ class PollsController < ApplicationController
     redirect_to :back
   end
 
+  def duplicate
+    redirect_to @poll.duplicate
+  end
+
   protected
 
   def set_layout

--- a/app/views/polls/show.haml
+++ b/app/views/polls/show.haml
@@ -70,6 +70,7 @@
 
 %hr
 
+= link_to _("Duplicate this poll"), duplicate_poll_path(@poll), :method => :post, :confirm => _("Are you sure you want to duplicate poll %{title}?") % {:title => @poll.title}, :class => 'farrange'
 = link_to _("Delete this poll"), poll_path(@poll), :method => :delete, :confirm => _("Are you sure you want to delete poll %{title}?") % {:title => @poll.title}, :class => 'fdelete'
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,7 @@ Pollit::Application.routes.draw do
         post 'register_channel/:ticket_code', :action => 'register_channel'
         post 'pause'
         post 'resume'
+        post 'duplicate'
 
         post 'run_next_job'
       end

--- a/spec/controllers/polls_controller_spec.rb
+++ b/spec/controllers/polls_controller_spec.rb
@@ -188,4 +188,23 @@ describe PollsController do
     Poll.find_by_id(p.id).should be_nil
   end
 
+  it "duplicates poll" do
+    poll = Poll.make!(owner: controller.current_user)
+    respondent = poll.respondents.make!
+
+    poll.start
+
+    post :duplicate, id: poll.id
+
+    duplicate = Poll.last
+    duplicate.id.should_not eq(poll.id)
+    duplicate.title.should eq("#{poll.title} (Copy)")
+    duplicate.status.should eq(:configuring)
+
+    dup_questions = duplicate.questions
+    dup_questions.count.should eq(poll.questions.count)
+
+    dup_respondents = duplicate.respondents
+    dup_respondents.count.should eq(poll.respondents.count)
+  end
 end

--- a/spec/models/poll_spec.rb
+++ b/spec/models/poll_spec.rb
@@ -75,4 +75,19 @@ describe Poll do
       poll.destroy
     end
   end
+
+  it "duplicates poll" do
+    poll = Poll.make! title: "Some poll"
+    duplicate = poll.duplicate
+    duplicate.title.should eq("#{poll.title} (Copy)")
+
+    duplicate2 = duplicate.duplicate
+    duplicate2.title.should eq("Some poll (Copy 2)")
+
+    duplicate3 = duplicate2.duplicate
+    duplicate3.title.should eq("Some poll (Copy 3)")
+
+    duplicate4 = duplicate.duplicate
+    duplicate4.title.should eq("Some poll (Copy 4)")
+  end
 end


### PR DESCRIPTION
This adds a button to the UI to duplicate a poll.

<img width="549" alt="screenshot 2016-02-15 11 29 30" src="https://cloud.githubusercontent.com/assets/209371/13051332/708e4cb8-d3d7-11e5-918d-adcd9df6b0db.png">

When you click it a confirmation appears:

<img width="722" alt="screenshot 2016-02-15 11 30 17" src="https://cloud.githubusercontent.com/assets/209371/13051345/807eab68-d3d7-11e5-8db7-bbe418b68716.png">

If you click "OK" the poll will be duplicated with a name "{old name} (Copy)", and the browser is redirected to that poll.

<img width="532" alt="screenshot 2016-02-15 11 30 57" src="https://cloud.githubusercontent.com/assets/209371/13051362/9982ef8e-d3d7-11e5-89c4-99c2ebd5edad.png">

From there you can edit the poll.

If you duplicate this new poll, it will have the name "Test Poll (Copy 2)", etc.