### PR TITLE
Fixes #48: Branching off for numeric answers

### DIFF
--- a/app/views/polls/form_editor/_question_form.haml
+++ b/app/views/polls/form_editor/_question_form.haml
@@ -40,10 +40,48 @@
     %input{ko(checked: 'collects_respondent', disable: 'poll.status_started()').merge(:class => 'feditor-capture-respondent', :title => "This question will not be sent to the respondents, but will be used to automatically store their phone numbers in the responses spreadsheet.", :type => "checkbox", :value => "1")}
     %span Stores sender phone number
 
-  - ko_if '(kind_numeric() || kind_text()) && $parent.kind_manual()' do
+  - ko_if 'kind_text() && $parent.kind_manual()' do
     %hr
     %p.title Go to question
     %p.smalltext After answering this question, go to
+    %select.next-question{ko(value: 'next_question', options: 'next_questions', optionsText: '"title"', optionsCaption: '"Next question"', disable: 'readonly', style: {'borderColor' => 'next_question_colour'}).merge(class: 'w30')}
+
+  - ko_if 'kind_numeric() && $parent.kind_manual()' do
+    %hr
+    %p.title Go to question
+    %p.smalltext Add a condition
+
+    If
+    %input{type: "number", :"data-bind" => "value:numeric_condition().min", style: "width: 40px"}
+    %span.smalltext to
+    %input{type: "number", :"data-bind" => "value:numeric_condition().max", style: "width: 40px"}
+    %select.option-next-question{ko(value: 'numeric_condition().next_question', options: 'next_questions', optionsText: '"title_for_options"', optionsCaption: '"Next question"', disable: 'readonly', style: {'borderColor' => 'next_question_colour'}), style: "width: 130px"}
+    %button.right.clist-add{ko(click: 'add_numeric_condition')}
+    .clear
+
+    %hr
+
+    /ko if: numeric_conditions().length > 0
+    %p.smalltext After answering this question
+    //ko
+
+    /ko if: numeric_conditions().length == 0
+    %p.smalltext After answering this question, go to
+    //ko
+
+    %div{ko(foreach: 'numeric_conditions')}
+      If
+      %input{type: "number", :"data-bind" => "value:min", style: "width: 40px"}
+      %span.smalltext to
+      %input{type: "number", :"data-bind" => "value:max", style: "width: 40px"}
+      %select.option-next-question{ko(value: 'next_question', options: '$parent.next_questions()', optionsText: '"title_for_options"', optionsCaption: '"Next question"', disable: '$parent.readonly', style: {'borderColor' => '$parent.next_question_colour'}), style: "width: 130px"}
+      %button.right.clist-remove.removeoption{ko(click: 'remove', visible: '$parent.editable()')}
+      .clear
+
+    /ko if: numeric_conditions().length > 0
+    Otherwise:
+    //ko
+
     %select.next-question{ko(value: 'next_question', options: 'next_questions', optionsText: '"title"', optionsCaption: '"Next question"', disable: 'readonly', style: {'borderColor' => 'next_question_colour'}).merge(class: 'w30')}
 
   - ko_if 'kind_options' do


### PR DESCRIPTION
The UI changes to allow adding numeric conditions and selecting the next question:

![screenshot 2016-02-16 16 21 45](https://cloud.githubusercontent.com/assets/209371/13088054/76db173e-d4c9-11e5-8a30-ecc6b561f02f.png)

The min/max are optional, so you can branch if only one of the conditions is met (i.e.: greater than 5 => go to question 2). 

After you add a condition:

![screenshot 2016-02-16 16 23 26](https://cloud.githubusercontent.com/assets/209371/13088085/9f2fcec8-d4c9-11e5-84e3-e1e921787ba0.png)

So the logic is: if the first condition is met, go to question X. Otherwise: go to question Y, etc.

The UI should be improved as it can be a bit confusing, but the logic would stay the same.