### PR TITLE
Fixed #52: allow choosing multile options keys, as well as the explanation message on how to reply

### DIFF
--- a/app/assets/javascripts/viewmodels/poll.js.coffee
+++ b/app/assets/javascripts/viewmodels/poll.js.coffee
@@ -25,13 +25,19 @@ class @Question
     @custom_message_not_a_number = ko.observable(custom_messages.not_a_number)
     @custom_message_number_not_in_range = ko.observable(custom_messages.number_not_in_range)
     @custom_message_not_an_option = ko.observable(custom_messages.not_an_option)
+    @custom_message_options_explanation = ko.observable(custom_messages.options_explanation)
 
     # Numeric conditions
     @numeric_condition = ko.observable(new QuestionNumericCondition(@))
     @numeric_conditions = ko.observableArray()
 
     # Options list
-    @options = ko.observableArray(_.map(data.options, (opt) => new QuestionOption(@, opt)))
+    @options = ko.observableArray(_.map(data.options, (opt) =>
+      if typeof(opt) == "string"
+        new QuestionOption(@, opt)
+      else
+        new QuestionOption(@, opt[0], opt[1])
+      ))
 
     # Toggle collect respondent
     @collects_respondent = ko.observable(data.collects_respondent)
@@ -46,7 +52,7 @@ class @Question
     @first = ko.computed () => @poll.questions()[0] == @
     @last = ko.computed () => !@editable() && @poll.questions()[@poll.questions().length-1] == @
     @active = ko.observable false
-    @new_option = ko.observable new QuestionOption(@, "")
+    @new_option = ko.observable new QuestionOption(@, "", "")
 
     @editor_class = ko.computed () =>
       (if @active() then 'active ' else ' ') + (@poll.editor_class_for(@kind()))
@@ -135,8 +141,9 @@ class @Question
 
 class @QuestionOption
 
-  constructor: (@question, text, hasFocus=false) ->
+  constructor: (@question, text, key, hasFocus=false) ->
     @text = ko.observable text
+    @key = ko.observable key
     @focus= ko.observable hasFocus
     @next_question = ko.observable()
     @next_question_colour = ko.computed () => @next_question()?.question_colour?() || 'transparent'
@@ -146,7 +153,7 @@ class @QuestionOption
 
   add: () ->
     @question.options.push @
-    new_option = new QuestionOption(@question, "", true)
+    new_option = new QuestionOption(@question, "", "", true)
     @question.new_option(new_option)
 
   onEnter: (q, e) ->

--- a/app/models/poll/accept_answers.rb
+++ b/app/models/poll/accept_answers.rb
@@ -83,7 +83,8 @@ module Poll::AcceptAnswers
 
     if option.nil?
       return question_reply(question, "not_an_option") {
-        invalid_reply_options % [question.options.join("|")]
+        options = question.options.map { |opt| opt.is_a?(Array) ? opt[0] : opt }
+        invalid_reply_options % [options.join("|")]
       }
     else
       answer = create_answer question, respondent, option

--- a/app/views/polls/form_editor/_question_form.haml
+++ b/app/views/polls/form_editor/_question_form.haml
@@ -86,10 +86,11 @@
 
   - ko_if 'kind_options' do
     %p.title Options
-    %p.smalltext Possible values for this question.
+    %p.smalltext Possible keys and values for this question.
     %ul.feditor-form-options.clist.w30
       %li.feditor-form-option{ko(foreach: 'options')}
-        = text_field_tag "#{f.object_name}[options][]", nil, :'data-bind' => 'attr: {readonly: $parent.readonly()}, value: text', :class => "ux-clist", :style => "width: 200px !important"
+        = text_field_tag "#{f.object_name}[keys][]", nil, :'data-bind' => 'attr: {readonly: $parent.readonly()}, value: key', :class => "ux-clist", :style => "width: 30px !important"
+        = text_field_tag "#{f.object_name}[options][]", nil, :'data-bind' => 'attr: {readonly: $parent.readonly()}, value: text', :class => "ux-clist", :style => "width: 150px !important"
         %select.option-next-question{ko(value: 'next_question', options: '$parent.next_questions()', optionsText: '"title_for_options"', optionsCaption: '$parent.options_caption', disable: '$parent.readonly()', visible: '$parent.poll.kind_manual()', style: {'borderColor' => 'next_question_colour'})}
         %button.right.clist-remove.removeoption{ko(click: 'remove', visible: '$parent.editable()')}
       .clear
@@ -98,7 +99,8 @@
 
   - ko_if 'editable() && kind_options()' do
     .feditor-form-option-new.require_from_group{ko(with: 'new_option')}
-      %input.newoption.small.option{ko(textInput: 'text', hasFocus: 'focus', event: { keypress: 'onEnter' }), type: 'text', placeholder: 'Enter a new option'}
+      %input.option{ko(textInput: 'key', event: { keypress: 'onEnter' }), type: 'text', placeholder: 'Key', style: 'width: 30px'}
+      %input.option{ko(textInput: 'text', hasFocus: 'focus', event: { keypress: 'onEnter' }), type: 'text', placeholder: 'Enter a new option', style: 'width: 150px'}
       %buttom.right.addoption.clist-add{ko(click: 'add', visible: '(text().length > 0)')}
     .clear
 
@@ -122,4 +124,9 @@
     %p.smalltext The response is not an option
     = f.text_field :custom_message_not_an_option, placeholder: "(default message)"
 
+  - ko_if 'kind_options' do
+    %hr
+    %p.title "How to reply" message
+    %p.smalltext Message explaining how to reply to this question
+    = f.text_field :custom_message_options_explanation, placeholder: "(default message)"
 

--- a/spec/models/poll/workflow_spec.rb
+++ b/spec/models/poll/workflow_spec.rb
@@ -79,6 +79,29 @@ describe Poll do
       p.respondents.first.answers.count.should_not eq(0)
     end
 
+    it "should send next question if option response is valid (with keys)" do
+      p = Poll.make!(:with_option_questions)
+
+      q = p.questions[0]
+      q.keys = %w(xy yz zx)
+      q.save!
+
+      p.reload
+
+      p.stubs(:send_messages).returns(true)
+      p.start
+
+      p.accept_answer("yes", p.respondents.first)
+      reply = p.accept_answer("lalala", p.respondents.first)
+      reply.should include("foo|bar|baz")
+
+      p.respondents.first.current_question_id.should_not eq(p.questions.first.lower_item.id)
+      p.respondents.first.answers.count.should eq(0)
+      p.accept_answer("yz", p.respondents.first)
+      p.respondents.first.current_question_id.should eq(p.questions.first.lower_item.id)
+      p.respondents.first.answers.count.should_not eq(0)
+    end
+
     it "should send next question if the numeric answer is valid" do
       p = Poll.make!(:with_numeric_questions)
       p.stubs(:send_messages).returns(true)

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -32,6 +32,18 @@ describe Question do
     question.options.should_not be_empty
   end
 
+  it "can be saved successfully with options and keys" do
+    question = Question.make(:options)
+    original_options = question.options
+    original_keys = question.options.map.with_index { |o, i| i.to_s }
+
+    question.keys = original_keys
+    question.save!
+
+    question.should be_persisted
+    question.options.should eq(original_options.zip(original_keys))
+  end
+
   it "has many answers" do
     question = Question.make!(:answers => [Answer.make!(:response => 'foo'), Answer.make!(:response => 'bar')])
     question.reload.should have(2).answers
@@ -51,6 +63,16 @@ describe Question do
     it "can be set to message being numeric" do
       Question.make!(:numeric, :title => "A numeric question?", :numeric_min => 1, :numeric_max => 4).message.should\
         eq("A numeric question? 1-4")
+    end
+
+    it "uses keys in options" do
+      q = Question.make!(:options, :title => "An options question?", :options => %w(foo bar baz), :keys => %w(x y z))
+      q.message.should eq("An options question? x-foo y-bar z-baz")
+    end
+
+    it "uses custom message in options" do
+      q = Question.make!(:options, :title => "An options question?", :options => %w(foo bar baz), :custom_message_options_explanation => "Say this and that")
+      q.message.should eq("An options question? Say this and that")
     end
   end
 


### PR DESCRIPTION
![screenshot 2016-02-17 14 27 36](https://cloud.githubusercontent.com/assets/209371/13118354/a2964b78-d582-11e5-8e73-b625f9a76d80.png)

If no key is specified for an option, the default is used (first is "a", second is "b", etc.)

Even though the screenshot shows one char for each key, keys can be longer.