### PR TITLE
Started with multple channels per poll. Fixes #47

### DIFF
--- a/acceptance/spec/selenium/polls/add_fail_channel_spec.rb
+++ b/acceptance/spec/selenium/polls/add_fail_channel_spec.rb
@@ -1,17 +1,17 @@
 # Copyright (C) 2011-2012, InSTEDD
-# 
+#
 # This file is part of Pollit.
-# 
+#
 # Pollit is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # Pollit is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with Pollit.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -22,7 +22,7 @@ acceptance_test do
   login_as "mmuller+4691@manas.com.ar", "123456789"
   go_to_my_polls
   @driver.find_element(:xpath, "//table[contains(@class, 'GralTable TwoColumn CleanTable ItemsTable')]/tbody/tr[10]").click
-  @driver.find_element(:link, "Manage Channel").click
+  @driver.find_element(:link, "Manage Channels").click
   sleep 5
   @driver.find_element(:id, "desktopLocalGateway").click
   @driver.find_element(:id, "next").click

--- a/acceptance/spec/selenium/polls/change_fail_channel_spec.rb
+++ b/acceptance/spec/selenium/polls/change_fail_channel_spec.rb
@@ -1,17 +1,17 @@
 # Copyright (C) 2011-2012, InSTEDD
-# 
+#
 # This file is part of Pollit.
-# 
+#
 # Pollit is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # Pollit is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with Pollit.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -29,10 +29,10 @@ acceptance_test do
   end
 
   fail "No poll with zero answers was found"
-  
+
   @driver.find_element(:xpath, "//table[contains(@class, 'GralTable TwoColumn CleanTable ItemsTable')]/tbody/tr[5]").click
-  @driver.find_element(:link, "Manage Channel").click
-  @driver.find_element(:link, "Change channel").click
+  @driver.find_element(:link, "Manage Channels").click
+  @driver.find_element(:link, "Add channel").click
   sleep 5
   @driver.find_element(:id, "desktopLocalGateway").click
   @driver.find_element(:id, "next").click

--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -20,9 +20,9 @@ class ChannelsController < ApplicationController
   before_filter :authenticate_user!
   before_filter :load_poll
 
-  def show
-    redirect_to :action => 'new', :wizard => params[:wizard] and return unless @poll.channel
-    @channel = @poll.channel
+  def index
+    redirect_to :action => 'new', :wizard => params[:wizard] and return if @poll.channels.empty?
+    @channels = @poll.channels.to_a
     render :layout => 'wizard' if params[:wizard]
   end
 
@@ -35,9 +35,7 @@ class ChannelsController < ApplicationController
   end
 
   def create
-    @poll.channel.destroy if @poll.channel
     @channel = @poll.register_channel(params[:channel][:ticket_code])
-
     if @channel.valid?
       if params[:wizard]
         redirect_to poll_respondents_path(@poll, :wizard => true)
@@ -45,7 +43,7 @@ class ChannelsController < ApplicationController
         set_current_step("d_end_wizard")
         render 'new'
       else
-        redirect_to new_poll_channel_path(@poll, "d_end_wizard")
+        redirect_to new_poll_channels_path(@poll, "d_end_wizard")
       end
     else
       set_current_step(params[:next_step])
@@ -54,9 +52,10 @@ class ChannelsController < ApplicationController
   end
 
   def destroy
-    @poll.channel.destroy if @poll.channel
+    channel = @poll.channels.where(id: params[:id]).first
+    channel.destroy if channel
     flash[:notice] = _('Channel successfully deleted')
-    redirect_to poll_path(@poll)
+    redirect_to poll_channels_path(@poll)
   end
 
   protected

--- a/app/controllers/nuntium_controller.rb
+++ b/app/controllers/nuntium_controller.rb
@@ -1,17 +1,17 @@
 # Copyright (C) 2011-2012, InSTEDD
-# 
+#
 # This file is part of Pollit.
-# 
+#
 # Pollit is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # Pollit is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with Pollit.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -20,13 +20,19 @@ class NuntiumController < ApplicationController
 
   def receive_at
     logger.debug "Received nuntium message: #{params.inspect}"
-    
+
     begin
-      poll = Poll.includes(:channel).where("channels.name = ?", params[:channel]).first
+      channel = Channel.where(name: params[:channel]).first
+      poll = channel.poll
       respondent = poll.respondents.find_by_phone(params[:from])
 
       if respondent.nil? || poll.nil?
         render :nothing => true and return
+      end
+
+      unless respondent.channel_id
+        respondent.channel = channel
+        respondent.save!
       end
 
       next_message = poll.accept_answer(params[:body], respondent)

--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -38,6 +38,7 @@ class PollsController < ApplicationController
   end
 
   def show
+    @channels = @poll.channels.to_a
   end
 
   def new
@@ -78,7 +79,7 @@ class PollsController < ApplicationController
     # Update
     if @poll.update_attributes(params[:poll])
       if params[:wizard]
-        redirect_to poll_channel_path(@poll, :wizard => true)
+        redirect_to poll_channels_path(@poll, :wizard => true)
       else
         redirect_to @poll, :notice => "Poll #{@poll.title} has been updated"
       end

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -24,7 +24,7 @@ class Poll < ActiveRecord::Base
   has_many :respondents, :dependent => :destroy
   has_many :answers, :through => :respondents
 
-  has_one :channel, :dependent => :destroy
+  has_many :channels, :dependent => :destroy
 
   has_recurrence :recurrence
 
@@ -88,7 +88,7 @@ class Poll < ActiveRecord::Base
   end
 
   def can_be_started?
-    status_configuring? && channel && respondents.any?
+    status_configuring? && channels.any? && respondents.any?
   end
 
   def pause
@@ -106,16 +106,11 @@ class Poll < ActiveRecord::Base
     self.save
   end
 
-  def as_channel_name
-    "#{title}-#{id}".parameterize
-  end
-
   def register_channel(ticket_code)
-    Channel.create({
+    channels.create(
       :ticket_code => ticket_code,
-      :name => as_channel_name,
-      :poll_id => id
-    })
+      :name => "#{title}-#{id}-#{Time.now.to_i}".parameterize,
+    )
   end
 
   def completion_percentage

--- a/app/models/respondent.rb
+++ b/app/models/respondent.rb
@@ -19,6 +19,7 @@ class Respondent < ActiveRecord::Base
   has_many :answers, :dependent => :destroy
   belongs_to :current_question, :class_name => Question.name
   belongs_to :poll
+  belongs_to :channel
 
   validates :phone, :presence => true, :uniqueness => { :scope => :poll_id }
 

--- a/app/views/channels/index.haml
+++ b/app/views/channels/index.haml
@@ -1,26 +1,27 @@
 - unless wizard?
-  - add_breadcrumb _("Channel"), poll_channel_path(@poll.id)
+  - add_breadcrumb _("Channel"), poll_channels_path(@poll.id)
   = render :partial => 'shared/poll_tabs', :locals => { :poll => @poll, :active_tab => 'channel' }
 
 %h1 Channel
 
 %div{:style => "margin-top:-10px;margin-bottom:15px;"}
   A channel created on Nuntium Local Gateway enables you to send polls from your mobile phone
-- if @poll.channel
+
+- @channels.each do |channel|
   .CurrentChannelBox.box.grey
     .left
       %p.black Local Gateway channel
       %p.grey
-        Bidirectional (#{@channel.unprefixed_address})
-        - if @channel.last_activity
-          last activity #{time_ago_in_words @poll.channel.last_activity} ago
-    = link_to_unless wizard?, '', poll_channel_path(@poll), :method => :delete, :class => 'icon fdelete right', :confirm => _("Are you sure you want to delete this channel?")
+        Bidirectional (#{channel.unprefixed_address})
+        - if channel.last_activity
+          last activity #{time_ago_in_words channel.last_activity} ago
+    = link_to_unless wizard?, '', poll_channel_path(@poll, channel), :method => :delete, :class => 'icon fdelete right', :confirm => _("Are you sure you want to delete this channel?")
 
 .LocalGatewayBox.box
   .LocalGatewayLogo.left
   .LocalGatewayText.left
     will help you to send polls from your mobile phone, #{link_to 'learn More', tour_path(1)}.
-  = grey_link_to _('Change channel'), new_poll_channel_path(@poll, :wizard => wizard?), :class => 'right'
+  = grey_link_to _('Add a channel'), new_poll_channel_path(@poll, :wizard => wizard?), :class => 'right'
   .LocalGatewayArrow.right
 
 - if wizard?

--- a/app/views/channels/wizard/_c_new_channel.haml
+++ b/app/views/channels/wizard/_c_new_channel.haml
@@ -1,4 +1,4 @@
-= form_for :channel, :url => poll_channel_path(@poll), :remote => (!params[:wizard]), :html => { :class => :validate} do |f|
+= form_for :channel, :url => poll_channels_path(@poll), :remote => (!params[:wizard]), :html => { :class => :validate} do |f|
   - if params[:wizard]
     = hidden_field_tag :wizard, 1
   = hidden_field_tag :next_step, "c_new_#{gateway}_channel"

--- a/app/views/channels/wizard/_d_end_wizard.haml
+++ b/app/views/channels/wizard/_d_end_wizard.haml
@@ -6,4 +6,4 @@
   .ChannelConfigured
 %hr/
 .ChannelWizardNavigation.actions
-  = white_link_to _('Finish'), poll_channel_path(@poll)
+  = white_link_to _('Finish'), poll_channels_path(@poll)

--- a/app/views/polls/show.haml
+++ b/app/views/polls/show.haml
@@ -26,16 +26,20 @@
       respondents
   = link_to _("Manage Respondents"), poll_respondents_path(@poll), :class => 'farrow'
 
-.box.overview{:class => ('incomplete' if @poll.channel.nil?)}
+.box.overview{:class => ('incomplete' if @poll.channels.empty?)}
   .i48grad-channel.icon
   .content
-    - if @poll.channel.nil?
+    - if @channels.empty?
       There is no channel set for this poll
-    - else
+    - elsif @channels.one?
       Channel
       %br
-      = @poll.channel.unprefixed_address
-  = link_to _("Manage Channel"), poll_channel_path(@poll), :class => 'farrow'
+      = @channels.first.unprefixed_address
+    - else
+      #{@channels.count} channels
+      %br
+      #{@channels.first.unprefixed_address}, ...
+  = link_to _("Manage Channels"), poll_channels_path(@poll), :class => 'farrow'
 
 - if @poll.kind_gforms?
   .box.overview

--- a/app/views/respondents/index.haml
+++ b/app/views/respondents/index.haml
@@ -102,5 +102,5 @@
 
     - if wizard?
       .actions
-        = white_link_to _("Back"), poll_channel_path(@poll, :wizard => true)
+        = white_link_to _("Back"), poll_channels_path(@poll, :wizard => true)
         = grey_link_to _("Next"), poll_path(@poll, :wizard => true)

--- a/app/views/shared/_poll_tabs.haml
+++ b/app/views/shared/_poll_tabs.haml
@@ -14,7 +14,7 @@
   %li#respondents
     = link_to _("Respondents"), poll_respondents_path(poll)
   %li#channel
-    = link_to _("Channel"), poll_channel_path(poll)
+    = link_to _("Channels"), poll_channels_path(poll)
   %li#settings
     = link_to _("Settings"), edit_poll_path(poll)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,7 +62,7 @@ Pollit::Application.routes.draw do
         post 'run_next_job'
       end
 
-      resource :channel, :only => [:show, :new, :create, :destroy]
+      resources :channels, :only => [:index, :new, :create, :destroy]
 
       resources :respondents, :only => [:index, :destroy] do
         collection do

--- a/db/migrate/20160218194359_add_channel_id_to_respondents.rb
+++ b/db/migrate/20160218194359_add_channel_id_to_respondents.rb
@@ -1,0 +1,5 @@
+class AddChannelIdToRespondents < ActiveRecord::Migration
+  def change
+    add_column :respondents, :channel_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160211211652) do
+ActiveRecord::Schema.define(:version => 20160218194359) do
 
   create_table "answers", :force => true do |t|
     t.integer  "respondent_id"
@@ -144,6 +144,7 @@ ActiveRecord::Schema.define(:version => 20160211211652) do
     t.integer  "current_question_id"
     t.boolean  "current_question_sent", :default => false, :null => false
     t.string   "hub_source"
+    t.integer  "channel_id"
   end
 
   add_index "respondents", ["phone", "poll_id"], :name => "index_respondents_on_phone_and_poll_id", :unique => true

--- a/spec/blueprints.rb
+++ b/spec/blueprints.rb
@@ -52,7 +52,7 @@ Poll.blueprint do
   form_url        {Sham.url}
   post_url        {Sham.url}
   owner           {User.make}
-  channel         {Channel.make}
+  channels         { [Channel.make] }
   questions(1)
 end
 
@@ -62,13 +62,13 @@ Poll.blueprint(:with_respondents) do
   form_url        {Sham.url}
   post_url        {Sham.url}
   owner           {User.make}
-  channel         { Channel.make }
+  channels        { [Channel.make] }
   questions(1)
   respondents(3)
 end
 
 Poll.blueprint(:with_questions) do
-  channel           {Channel.make}
+  channels          { [Channel.make] }
   title             {Sham.title}
   description       {Sham.description}
   form_url          {Sham.url}
@@ -83,7 +83,7 @@ Poll.blueprint(:with_questions) do
 end
 
 Poll.blueprint(:with_text_questions) do
-  channel           {Channel.make}
+  channels          { [Channel.make] }
   title             {Sham.title}
   description       {Sham.description}
   form_url          {Sham.url}
@@ -97,7 +97,7 @@ Poll.blueprint(:with_text_questions) do
 end
 
 Poll.blueprint(:with_collecting_respondent_question) do
-  channel           {Channel.make}
+  channels          { [Channel.make] }
   title             {Sham.title}
   description       {Sham.description}
   form_url          {Sham.url}
@@ -111,7 +111,7 @@ Poll.blueprint(:with_collecting_respondent_question) do
 end
 
 Poll.blueprint(:with_option_questions) do
-  channel       {Channel.make}
+  channels      { [Channel.make] }
   title         {Sham.title}
   description   {Sham.description}
   form_url      {Sham.url}
@@ -124,7 +124,7 @@ Poll.blueprint(:with_option_questions) do
 end
 
 Poll.blueprint(:with_numeric_questions) do
-  channel       {Channel.make}
+  channels      { [Channel.make] }
   title         {Sham.title}
   description   {Sham.description}
   form_url      {Sham.url}
@@ -189,7 +189,7 @@ class Poll
   def self.plan(*args)
     poll = self.make(*args)
     plan = poll.serializable_hash
-    plan.delete :channel
+    plan.delete :channels
     plan.delete :questions
     plan["questions_attributes"] = {}
     (poll.questions || []).each_with_index do |question,index|

--- a/spec/controllers/nuntium_controller_spec.rb
+++ b/spec/controllers/nuntium_controller_spec.rb
@@ -40,13 +40,16 @@ describe NuntiumController do
 
     nuntium_http_login
     post :receive_at, {
-      :channel => p.channel.name,
+      :channel => p.channels.first.name,
       :from => p.respondents.first.phone,
       :body => "Yes"
     }
 
     @response.body.should eq(p.questions.first.message)
-    p.reload.respondents.first.confirmed.should be_true
+
+    respondent = p.reload.respondents.first
+    respondent.confirmed.should be_true
+    respondent.channel.should eq(p.channels.first)
   end
 
   it "should receive confirmation with multiple confirmation words" do
@@ -55,7 +58,7 @@ describe NuntiumController do
 
     nuntium_http_login
     post :receive_at, {
-      :channel => p.channel.name,
+      :channel => p.channels.first.name,
       :from => p.respondents.first.phone,
       :body => "Si"
     }


### PR DESCRIPTION
The channels section now lists all channels and lets you remove and add new ones.

![screenshot 2016-02-18 17 23 18](https://cloud.githubusercontent.com/assets/209371/13157166/17811a66-d665-11e5-8eb5-fd16281fb897.png)

The initial wizard lets you configure one channel. To add more channels you have to go to Manage Channels after the initial setup.

Additionally, we now associate the channel used for each respondent in the database, although this info is currently not shown anywhere.

No changes are needed in Nuntium or the local gateway: if there are many candidate channels Nuntium will automatically balance them, and then remember the used channel so that a respondent always talks to the same phone.

I didn't test it for real, we can try it with QA once we deploy this to staging.
