### PR TITLE
Fix #45: Show delivery status of last message for each respondent

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'knockoutjs-rails'
 gem 'knockout_forms-rails', git: "https://github.com/manastech/knockout_forms-rails.git", tag: 'v1.0.2'
 gem 'gon'
 gem 'activerecord-import', '~> 0.3.1'
+gem "guid"
 gem 'rgviz'
 gem 'rgviz-rails', :require => 'rgviz_rails'
 gem 'instedd_telemetry', git: 'https://github.com/instedd/telemetry_rails.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,6 +174,7 @@ GEM
       json
       multi_json
       request_store (>= 1.0.5)
+    guid (0.1.1)
     haml (4.0.5)
       tilt
     haml-rails (0.4)
@@ -375,6 +376,7 @@ DEPENDENCIES
   gettext!
   gettext_i18n_rails
   gon
+  guid
   haml-rails
   hpricot
   hub_client!

--- a/README.md
+++ b/README.md
@@ -16,6 +16,22 @@ Simply clone the repository and fill the following settings file before starting
     config/guisso.yml
     config/hub.yml
 
+Configuring Nuntium
+-------------------
+
+Nuntium settings are located in `config/nuntium.yml`.
+
+The Nuntium Application associated to a Pollit instance must be configured in this way:
+  * Application name: the value of `application` in `config/nuntium.yml`
+  * Interface configuration:
+    * HTTP Post callback: `/nuntium/receive_at`
+    * User: the value of `at_post_user` in `config/nuntium.yml`
+    * Password: the value of `at_post_password` in `config/nuntium.yml`
+  * Delivery acknowledgement:
+    * HTTP Post: `/nuntium/delivery_callback`
+    * User: the value of `at_post_user` in `config/nuntium.yml`
+    * Password: the value of `at_post_password` in `config/nuntium.yml`
+
 API
 ===
 

--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -267,7 +267,7 @@ label.placeholder {
 
 #respondents-list {
   .tablewrapp {
-    width: 300px;
+    width: 800px;
   }
 }
 

--- a/app/controllers/nuntium_controller.rb
+++ b/app/controllers/nuntium_controller.rb
@@ -48,6 +48,16 @@ class NuntiumController < ApplicationController
     end
   end
 
+  def delivery_callback
+    respondent = Respondent.find_by_ao_message_guid params[:guid]
+    if respondent
+      respondent.ao_message_state = params[:state]
+      respondent.save!
+    end
+
+    head :ok
+  end
+
   private
 
   def authenticate_nuntium_at_post

--- a/app/controllers/respondents_controller.rb
+++ b/app/controllers/respondents_controller.rb
@@ -97,7 +97,7 @@ class RespondentsController < ApplicationController
   private
 
   def load_respondents
-    @respondents = @poll.respondents.order("created_at DESC").page(params[:page]).per(15)
+    @respondents = @poll.respondents.includes(:channel, :current_question).order("created_at DESC").page(params[:page]).per(15)
   end
 
 end

--- a/app/views/respondents/_list.html.haml
+++ b/app/views/respondents/_list.html.haml
@@ -1,9 +1,33 @@
 #respondents-list
   .tablewrapp
-    = instedd_table_for @respondents, [_('Phone number'), ''], :class => "GralTable TwoColumn CleanTable w-pagination", :empty => _("No respondents have been set up yet") do |respondent|
+    = instedd_table_for @respondents, [_('Phone number'), _('Channel'), _('Current Question'), _('Status (*)'), ''], :class => "GralTable TwoColumn CleanTable w-pagination", :empty => _("No respondents have been set up yet") do |respondent|
       %tr
         %td= respondent.unprefixed_phone
+        %td= respondent.channel.try(:unprefixed_address)
+        %td
+          - if respondent.confirmed
+            - title = respondent.current_question.try(:title)
+            - if title
+              = truncate(title)
+          - else
+            Confirmation message
+        %td
+          - if respondent.current_question_sent
+            - if respondent.ao_message_state == 'confirmed'
+              Received by respondent
+            - elsif respondent.ao_message_state == 'delivered'
+              Received by channel
+            - else
+              Sent to channel
+          - else
+            Not sent
+        %td
         %td
           - if !respondent.hub_source && @poll.status_configuring?
             = link_to '', poll_respondent_path(@poll.id, respondent.id, page: @respondents.current_page), method: 'delete', remote: true, class: 'icon cremove'
     = paginate @respondents, :params => { action: 'index', :id => nil }, :remote => true, :window => 2
+
+%br
+%div
+  (*) Status: Not sent → Sent to channel → Received by channel → Received by respondent
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Pollit::Application.routes.draw do
     get 'community',    :action => :index, :controller => :community, :as => 'community'
 
     post 'nuntium/receive_at' => 'nuntium#receive_at'
+    post 'nuntium/delivery_callback' => 'nuntium#delivery_callback'
 
     resources :polls do
       collection do

--- a/db/migrate/20160222150915_add_ao_message_guid_to_respondents.rb
+++ b/db/migrate/20160222150915_add_ao_message_guid_to_respondents.rb
@@ -1,0 +1,5 @@
+class AddAoMessageGuidToRespondents < ActiveRecord::Migration
+  def change
+    add_column :respondents, :ao_message_guid, :string
+  end
+end

--- a/db/migrate/20160222170359_add_ao_message_state_to_respondents.rb
+++ b/db/migrate/20160222170359_add_ao_message_state_to_respondents.rb
@@ -1,0 +1,5 @@
+class AddAoMessageStateToRespondents < ActiveRecord::Migration
+  def change
+    add_column :respondents, :ao_message_state, :string
+  end
+end

--- a/db/migrate/20160222170715_add_index_respondents_by_ao_message_guid.rb
+++ b/db/migrate/20160222170715_add_index_respondents_by_ao_message_guid.rb
@@ -1,0 +1,5 @@
+class AddIndexRespondentsByAoMessageGuid < ActiveRecord::Migration
+  def up
+    add_index :respondents, :ao_message_guid, :unique => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160218194359) do
+ActiveRecord::Schema.define(:version => 20160222170715) do
 
   create_table "answers", :force => true do |t|
     t.integer  "respondent_id"
@@ -145,8 +145,11 @@ ActiveRecord::Schema.define(:version => 20160218194359) do
     t.boolean  "current_question_sent", :default => false, :null => false
     t.string   "hub_source"
     t.integer  "channel_id"
+    t.string   "ao_message_guid"
+    t.string   "ao_message_state"
   end
 
+  add_index "respondents", ["ao_message_guid"], :name => "index_respondents_on_ao_message_guid", :unique => true
   add_index "respondents", ["phone", "poll_id"], :name => "index_respondents_on_phone_and_poll_id", :unique => true
 
   create_table "users", :force => true do |t|

--- a/spec/controllers/nuntium_controller_spec.rb
+++ b/spec/controllers/nuntium_controller_spec.rb
@@ -66,4 +66,13 @@ describe NuntiumController do
     @response.body.should eq(p.questions.first.message)
     p.reload.respondents.first.confirmed.should be_true
   end
+
+  it "saves ao_message_state in respondent on delivery ack" do
+    r = Respondent.make! ao_message_guid: "foo"
+
+    nuntium_http_login
+    post :delivery_callback, guid: "foo", state: "delivered"
+
+    r.reload.ao_message_state.should eq("delivered")
+  end
 end

--- a/spec/models/poll_spec.rb
+++ b/spec/models/poll_spec.rb
@@ -90,4 +90,15 @@ describe Poll do
     duplicate4 = duplicate.duplicate
     duplicate4.title.should eq("Some poll (Copy 4)")
   end
+
+  it "sends messages and stores AO message guid in respondent" do
+    poll = Poll.make!
+    respondent = poll.respondents.make! ao_message_state: 'confirmed'
+
+    poll.send_messages [{respondent: respondent}]
+    respondent.reload
+
+    respondent.ao_message_guid.should_not be_nil
+    respondent.ao_message_state.should be_nil
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,9 +42,11 @@ RSpec.configure do |config|
     @nuntium.stubs(:delete_channel)
 
     @nuntium_ao_messages = []
-    @nuntium.stubs(:send_ao).with do |args|
-      @nuntium_ao_messages += args; true
-    end.returns(true)
+    @nuntium.stub(:send_ao) do |args|
+      args = [args] unless args.is_a?(Array)
+      @nuntium_ao_messages.concat args
+      {:guid => Guid.new.to_s}
+    end
   end
 end
 


### PR DESCRIPTION
This PR implements every point of #45 except the one where the local gateway notifies nuntium that the delivery was succesful (because that needs to be done in the local gateway and nuntium):
* Previously poll messages were sent in bulk. This has the inconvenience that we can't track them. So now messages are sent one by one and the GUID of nuntium AO messages are stored in each respondent, together with the message status (initially empty).
* Added an endpoint `/nunitum/delivery_callback` that needs to be configured in Nuntium, so that when a message state changes to `delivered` or `confirmed`, pollit gets notified. In this endpoint we lookup the respondent with that AO message GUID and set its status to whatever nuntium tells us.
* This status is shown in the respondents UI, together with what's the current question (or if just the confirmation message was sent). The associated channel is also shown, because now multiple channels might be configured for a poll. 
* Also added how to properly configure Nuntium in the Readme

This will need a new Nuntium deploy to work, because delivery ack for QST messages [was not working](https://github.com/instedd/nuntium/commit/af78e51346fb452b30a59418d3f0e5ddf2783a4f).

<img width="835" alt="screenshot 2016-02-22 15 42 07" src="https://cloud.githubusercontent.com/assets/209371/13228449/e047a1a0-d97a-11e5-8009-5ceca5b7391b.png">