### PR TITLE
Disable Devise sign ups if Guisso is enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set environment up
+        run: |
+          docker compose pull
+          docker compose up -d db
+          docker compose run --rm --no-deps web bundle
+          docker compose run --rm --no-deps web rake db:setup
+          docker compose run --rm --no-deps web rake db:test:prepare
+
+      - name: Run specs
+        run: |
+          docker compose run --rm web bundle exec rspec spec
+
+  build:
+    needs: test
+    runs-on: ubuntu-22.04
+    env:
+      DOCKER_REPOSITORY: 'instedd/pollit'
+      DOCKER_USER: ${{ secrets.DOCKER_USER }}
+      DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build image & push to Docker Hub
+        run: ./build.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM ruby:2.3
 
+# Cleanup expired Let's Encrypt CA (Sept 30, 2021)
+RUN sed -i '/^mozilla\/DST_Root_CA_X3/s/^/!/' /etc/ca-certificates.conf && update-ca-certificates -f
+
+RUN echo 'deb http://archive.debian.org/debian stretch main\n\
+  deb http://archive.debian.org/debian-security stretch/updates main' > /etc/apt/sources.list
+
 RUN \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,11 @@
 FROM ruby:2.3
 
+# Cleanup expired Let's Encrypt CA (Sept 30, 2021)
+RUN sed -i '/^mozilla\/DST_Root_CA_X3/s/^/!/' /etc/ca-certificates.conf && update-ca-certificates -f
+
+RUN echo 'deb http://archive.debian.org/debian stretch main\n\
+  deb http://archive.debian.org/debian-security stretch/updates main' > /etc/apt/sources.list
+
 RUN \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs && \

--- a/README.md
+++ b/README.md
@@ -38,22 +38,14 @@ Development
 Docker development
 ------------------
 
-`docker-compose.yml` file build a development environment mounting the current folder and running rails in development environment.
+`docker-compose.yml` file builds a development environment mounting the current folder and running rails in development environment.
 
-Run the following commands to have a stable development environment.
+To have a stable development environment, simply run `./dev-setup`.
 
-```
-$ docker-compose run --rm --no-deps web bundle install
-$ docker-compose up -d db
-$ docker-compose run --rm web rake db:setup
-$ docker-compose up
-```
-
-To setup and run test, once the web container is running:
+To run the test suite, once the web container is running (`docker compose up -d web`) run:
 
 ```
-$ docker-compose exec web bash
-root@web_1 $ rake
+docker compose exec web rake
 ```
 
 API

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -eo pipefail
+
+# This will load the script from this repository. Make sure to point to a specific commit so the build continues to work
+# event if breaking changes are introduced in this repository
+source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/manastech/ci-docker-builder/055890240f6cfd633839bb32f8d4deef83214aed/build.sh)"
+
+# Prepare the build
+dockerSetup
+
+# Write a VERSION file for the footer
+echo $VERSION > VERSION
+
+# Build and push the Docker image
+dockerBuildAndPush

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Pollit::Application.routes.draw do
 
   scope "(:locale)", :locale => /#{Locales.available.keys.join('|')}/ do
 
-    devise_for :users, :controllers => {
+    devise_for :users, :skip => [ ( :registrations if Guisso.enabled? ) ], :controllers => {
       :registrations => 'users/registrations',
       omniauth_callbacks: "omniauth_callbacks",
       sessions: "sessions"

--- a/dev-setup
+++ b/dev-setup
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+docker compose pull
+docker compose build
+docker compose run --rm --no-deps web bundle install
+docker compose up -d --wait db
+docker compose run --rm web rake db:setup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '2.0'
 services:
   db:
     image: mysql:5.6
+    platform: linux/amd64
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
     volumes:
@@ -12,6 +13,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
+    platform: linux/amd64
     working_dir: /app
     environment:
       RAILS_ENV:

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -eo pipefail
-
-source <(curl -s https://raw.githubusercontent.com/manastech/ci-docker-builder/e556ffa1319a966df778d3559a4b29505ca8dceb/travis-build.sh)
-
-dockerSetup
-echo $VERSION > VERSION
-dockerBuildAndPush


### PR DESCRIPTION
If we offload authorisations to Guisso, then avoid local users sign ups.

Guisso is CAPTCHA-protected, so we'd rather use it for production than add CATPCHA protections to each InSTEDD app.

The PR also workarounds some tech debt issues.